### PR TITLE
prependListener and prependOnceListener

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -37,3 +37,4 @@ require('./set-max-listeners-side-effects.js');
 require('./subclass.js');
 require('./remove-all-listeners.js');
 require('./remove-listeners.js');
+require('./prepend-listener.js');

--- a/tests/prepend-listener.js
+++ b/tests/prepend-listener.js
@@ -1,0 +1,45 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var EventEmitter = require('../');
+var assert = require('assert');
+
+var myEE = new EventEmitter();
+var m = 0;
+
+// This one comes last.
+myEE.on('foo', function () {
+  assert.strictEqual(m, 2);
+});
+
+// This one comes second.
+myEE.prependListener('foo', function () {
+  assert.strictEqual(m++, 1);
+});
+
+// This one comes first.
+myEE.prependOnceListener('foo', function () {
+  assert.strictEqual(m++, 0);
+});
+
+myEE.emit('foo');
+
+assert.strictEqual(m, 2);

--- a/uevents.js
+++ b/uevents.js
@@ -16,6 +16,8 @@ function EventEmitter(obj, options) {
 			once: {value: once},
 			off: {value: off},
 			addListener: {value: on},
+			prependListener: {value: prependListener},
+			prependOnceListener: {value: prependOnceListener},
 			removeListener: {value: off},
 			removeAllListeners: {value: off},
 			listeners: {value: listeners},
@@ -57,7 +59,7 @@ function EventEmitter(obj, options) {
 		function on(type, fn) {
 			if (_events.newListener) {obj.emit('newListener', type, fn)}
 			_events[type] = _events[type] || []
-			_events[type].push(fn);
+			_events[type][fn._prepend ? 'unshift': 'push'](fn);
 			// Check for listener leak
 			if (!_events[type].warned) {
 				var m = obj.maxListeners
@@ -73,6 +75,17 @@ function EventEmitter(obj, options) {
 		function once(type, fn) {
 			fn._once = 1
 			return obj.on(type, fn)
+		}
+
+		function prependListener(type, fn) {
+			fn._prepend = true;
+			return obj.on(type, fn);
+		}
+
+		function prependOnceListener(type, fn) {
+			fn._prepend = true;
+			fn._once = 1;
+			return obj.on(type, fn);
 		}
 
 		function off(type, fn) {


### PR DESCRIPTION
Add support for two missing functions from the Node.js API: prependListener and prependOnceListener

I have added the tests from the events library and tried to keep the code size to a minimum.